### PR TITLE
Update check_style.yml

### DIFF
--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install black
       - name: Check python style
         run: |
-          black --check .
+          black --check . --exclude 'code/experiments'
       - name: Check cpp style
         run: |
-          ! find . -type f \( -name '*.h' -or -name '*.cpp' \) | xargs clang-format -style=file --output-replacements-xml | grep -q 'replacement '
+          ! find . -type f \( -name '*.h' -or -name '*.cpp' \) -not -ipath './code/experiments/*' | xargs clang-format -style=file --output-replacements-xml | grep -q 'replacement '


### PR DESCRIPTION
I'd like to disable the automatic code formatting checks for the `interiorsim/experiments` folder. Here is my reasoning.

1. The intent of this folder is for quick-and-dirty experiments. Quick-and-dirty experiments don't demand the same level of quality as core code. For example, I want to use this folder for my sim-to-real correlation coefficient experiments (notebooks, code, data, other documentation). This code belongs in the interiorsim repository, but it is not core code.
2. Quick-and-dirty experiments often require a mix of code that we write ourselves and (lightly hacked versions of) third-party code. It's better to have the option of checking in third-party code as-is without comprehensive reformatting, because then it is easy to use diff to find minor modifications. If we force comprehensive reformatting on third-party code, it becomes impossible to use diff to find minor modifications. Indeed, nearly all of the formatting errors from my SRCC experiments are from third-party code that I needed to include and lightly hack to get things working.
3. The experiments folder can depend on other folders, but other folders should not depend on experiments. If this rule is followed, there is no danger of quick-and-dirty experiment code leaking into core code.