### PR TITLE
bugfix remove potential problematic collision callback

### DIFF
--- a/code/unreal_plugins/RobotSim/Source/SimpleVehicle/SimpleVehiclePawn.cpp
+++ b/code/unreal_plugins/RobotSim/Source/SimpleVehicle/SimpleVehiclePawn.cpp
@@ -345,7 +345,7 @@ void ASimpleVehiclePawn::NotifyHit(class UPrimitiveComponent* HitComponent,
     FString otherComponent = otherComp->GetName();
 
     std::cout << "    COLLISION    " << std::string(TCHAR_TO_UTF8(*hitComponent)) << "  ---  " << std::string(TCHAR_TO_UTF8(*otherComponent)) << std::endl;
-    this->pawnEvents_.getCollisionSignal().emit(HitComponent, OtherActor, otherComp, bSelfMoved, hitLocation, hitNormal, normalImpulse, hit);
+    // this->pawnEvents_.getCollisionSignal().emit(HitComponent, OtherActor, otherComp, bSelfMoved, hitLocation, hitNormal, normalImpulse, hit);
 }
 
 void ASimpleVehiclePawn::OnComponentCollision(UPrimitiveComponent* HitComponent,


### PR DESCRIPTION
`this->pawn_events_.getCollisionSignal()`  This function uses some very hacky functionality that might be the root cause of crash mentioned in the meeting. 