### PR TITLE
add back `r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True`

### DIFF
--- a/cpp/unreal_projects/SpearSim/Config/Windows/WindowsEngine.ini
+++ b/cpp/unreal_projects/SpearSim/Config/Windows/WindowsEngine.ini
@@ -2,6 +2,7 @@
 r.RayTracing=True
 r.SkinCache.CompileShaders=True
 r.Reflections.Denoiser=1
+r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
 
 [/Script/WindowsTargetPlatform.WindowsTargetSettings]
 DefaultGraphicsRHI=DefaultGraphicsRHI_DX12


### PR DESCRIPTION
Tested on main as of 0227b02c1880e287c76dce35758809fd5c2e8c8b. Windows, shipping build, ray tracing mode.


raytracing_with_param  |  raytracing_without_param
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/42787281/205590350-81cc6a7c-0cd3-419e-8ebc-50fbb6b5fd16.png)  |  ![](https://user-images.githubusercontent.com/42787281/205590458-658f743a-d500-4baf-acfd-029167badcb3.png)
![](https://user-images.githubusercontent.com/42787281/205590616-c5506d70-a01e-4495-8398-2de675fc82ce.png)  |  ![](https://user-images.githubusercontent.com/42787281/205590592-ecd9710e-9fa1-4ad3-a595-7ec2429e61de.png)


Also, tested on baked mode and looks like this doesn't affect images in baked mode.
