### PR TITLE
fixes needed for MuJoCo to correctly model Fetch

### DIFF
--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfLinkComponent.cpp
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfLinkComponent.cpp
@@ -39,7 +39,7 @@ void UUrdfLinkComponent::initializeComponent(UrdfLinkDesc* link_desc)
         float m_to_cm = 100.0f;
         UrdfLinkDesc* parent_link_desc = joint_desc->parent_link_desc_;
         FTransform link_origin_ = parent_link_desc->visual_descs_[0].origin_;
-        SetRelativeLocation((joint_desc->origin_.GetLocation() + link_desc->visual_descs_[0].origin_.GetLocation() - link_origin_.GetLocation()) * m_to_cm);
+        SetRelativeLocation((joint_desc->origin_.GetLocation() - link_desc->visual_descs_[0].origin_.GetLocation() - link_origin_.GetLocation()) * m_to_cm);
         SetRelativeRotation(joint_desc->origin_.GetRotation().Rotator() + link_desc->visual_descs_[0].origin_.GetRotation().Rotator());
     }
 

--- a/python/spear/urdf/fetch.xml
+++ b/python/spear/urdf/fetch.xml
@@ -522,20 +522,20 @@
             <inertia ixx="6.98014e-06" ixy="-2.62572e-08" ixz="-1.58206e-08" iyy="4.12665e-05" iyz="-1.57909e-09" izz="3.75763e-05"/>
         </inertial>
         <visual>
-            <origin rpy="0 0 0" xyz="0 -0.101425 0"/>
+            <origin rpy="0 0 0" xyz="0 0.101425 0"/>
             <geometry>
                 <mesh filename="StaticMesh'/UrdfBot/Fetch_V1/Meshes/gripper_finger_link_l.gripper_finger_link_l'"/>
             </geometry>
         </visual>
         <collision>
-            <origin rpy="0 0 0" xyz="0 -0.101425 0"/>
+            <origin rpy="0 0 0" xyz="0 0.101425 0"/>
             <geometry>
                 <mesh filename="StaticMesh'/UrdfBot/Fetch_V1/Meshes/gripper_finger_link_l.gripper_finger_link_l'"/>
             </geometry>
         </collision>
     </link>
     <joint name="gripper_finger_joint_l" type="prismatic">
-        <origin rpy="0 0 0" xyz="0 -0.015425 0"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
         <parent link="gripper_link"/>
         <child link="gripper_finger_link_l"/>
         <axis xyz="0 -1 0"/>
@@ -550,20 +550,20 @@
             <inertia ixx="6.15416e-06" ixy="-1.5025e-09" ixz="0" iyy="3.87474e-05" iyz="0" izz="3.55162e-05"/>
         </inertial>
         <visual>
-            <origin rpy="0 0 0" xyz="0 0.101425 0"/>
+            <origin rpy="0 0 0" xyz="0 -0.101425 0"/>
             <geometry>
                 <mesh filename="StaticMesh'/UrdfBot/Fetch_V1/Meshes/gripper_finger_link_r.gripper_finger_link_r'"/>
             </geometry>
         </visual>
         <collision>
-            <origin rpy="0 0 0" xyz="0 0.101425 0"/>
+            <origin rpy="0 0 0" xyz="0 -0.101425 0"/>
             <geometry>
                 <mesh filename="StaticMesh'/UrdfBot/Fetch_V1/Meshes/gripper_finger_link_r.gripper_finger_link_r'"/>
             </geometry>
         </collision>
     </link>
     <joint name="gripper_finger_joint_r" type="prismatic">
-        <origin rpy="0 0 0" xyz="0 0.015425 0"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
         <parent link="gripper_link"/>
         <child link="gripper_finger_link_r"/>
         <axis xyz="0 1 0"/>


### PR DESCRIPTION
To reproduce the error in MuJoCo:
- Unzip [urdf_meshes.zip](https://github.com/isl-org/spear/files/11300003/urdf_meshes.zip) containing STL meshes in to a directory called `urdf_meshes`.
- Run the following code (`convert_urdf.py`) to get an updated URDF with paths pointing to the STL meshes in `urdf_meshes`: `$ python convert_urdf.py --input fetch.xml --meshdir urdf_meshes`:
```python
import argparse
import xml.etree.ElementTree as ET
import os


osp = os.path


if __name__ == '__main__':
  parser = argparse.ArgumentParser()
  parser.add_argument('--input', required=True, help='Input URDF file')
  parser.add_argument('--meshdir', required=True, help='Directory containing ')
  args = parser.parse_args()
  
  filename = osp.expanduser(args.input)
  tree = ET.parse(filename)
  root = tree.getroot()

  # add mujoco tag and compiler options
  mujoco = ET.SubElement(root, 'mujoco')
  compiler = {'meshdir': osp.expanduser(args.meshdir), 'discardvisual': 'false'}
  compiler = ET.SubElement(mujoco, 'compiler', compiler)

  for child in root:
    if child.tag == 'link':
      visual = child.find('visual')
      visual_mesh = visual.find('geometry').find('mesh')
      collision = child.find('collision')
      collision_mesh = collision.find('geometry').find('mesh')
      if visual_mesh is None:
        visual_name = f'{child.get("name")}_visual'
        collision_name = f'{child.get("name")}_collision'
      else:
        asset_name = visual_mesh.get('filename')
        mesh_filename = asset_name[12:-1]
        mesh_filename = osp.split(mesh_filename)[-1].split('.')[-1]
        visual_name = f'{mesh_filename}_visual'
        visual_mesh.set('filename', f'{mesh_filename}_visual.stl')
        collision_name = f'{mesh_filename}_collision'
        collision_mesh.set('filename', f'{mesh_filename}_collision.stl')
      visual.set('name', visual_name)
      collision.set('name', collision_name)
      ET.SubElement(child, 'spear', {'assetpath': asset_name})

  out_filename = 'output.xml'
  tree.write(out_filename)
  print(f'{out_filename} written')
```
- It will produce `output.xml`. In a Python env containing installed deepmind/mujoco, run `$ python -m mujoco.viewer --mjcf output.xml`.