### PR TITLE
Fix two Linux launch bugs: stale run_executable config key + missing log import

### DIFF
--- a/python/spear/utils/system_utils.py
+++ b/python/spear/utils/system_utils.py
@@ -4,8 +4,7 @@
 #
 
 import os
-
-from .log_utils import log
+import spear
 
 # perform configuration steps that should only be done once per system, as opposed to once per instance
 def configure_system(config):
@@ -13,5 +12,5 @@ def configure_system(config):
     # set environment variables
     if config.SPEAR.LAUNCH_MODE in ["editor", "game"]:
         for environment_var_name, environment_var_value in config.SPEAR.ENVIRONMENT_VARS.items():
-            log("Setting environment variable: ", environment_var_name, " = ", environment_var_value)
+            spear.log("Setting environment variable: ", environment_var_name, " = ", environment_var_value)
             os.environ[environment_var_name] = environment_var_value

--- a/python/spear/utils/system_utils.py
+++ b/python/spear/utils/system_utils.py
@@ -5,6 +5,8 @@
 
 import os
 
+from .log_utils import log
+
 # perform configuration steps that should only be done once per system, as opposed to once per instance
 def configure_system(config):
 

--- a/tools/run_executable.py
+++ b/tools/run_executable.py
@@ -56,8 +56,8 @@ if __name__ == "__main__":
         config.SP_SERVICES.INITIALIZE_ENGINE_SERVICE.BENCHMARKING = False
 
     if not args.skip_override_game_paused:
-        config.SP_SERVICES.INITIALIZE_GAME_WORLD_SERVICE.OVERIDE_GAME_PAUSED = True
-        config.SP_SERVICES.INITIALIZE_GAME_WORLD_SERVICE.GAME_PAUSED = False
+        config.SP_SERVICES.WORLD_REGISTRY_SERVICE.OVERRIDE_GAME_PAUSED = True
+        config.SP_SERVICES.WORLD_REGISTRY_SERVICE.GAME_PAUSED = False
 
     if args.graphics_adaptor is not None:
         config.SPEAR.INSTANCE.COMMAND_LINE_ARGS.graphics_adaptor = args.graphics_adaptor


### PR DESCRIPTION
Two small, independent fixes that block launching SpearSim from Python on **Linux**:

1. **`tools/run_executable.py`** — the game-paused override referenced `SP_SERVICES.INITIALIZE_GAME_WORLD_SERVICE.OVERIDE_GAME_PAUSED`, a service that doesn't exist in the config (and `OVERIDE` was misspelled), raising `AttributeError` on every launch. Corrected to `SP_SERVICES.WORLD_REGISTRY_SERVICE.OVERRIDE_GAME_PAUSED` / `.GAME_PAUSED`, matching `default_config.sp_services.yaml` and `WorldRegistryService.h`.

2. **`python/spear/utils/system_utils.py`** — `configure_system()` calls `log()` without importing it, raising `NameError` whenever `SPEAR.ENVIRONMENT_VARS` is non-empty. This triggers on Linux via `run_executable.py --vk-icd-filenames` (macOS/Metal never sets `VK_ICD_FILENAMES`, so the loop body never runs — which is why it went unnoticed). Added `from .log_utils import log`.

Both verified on Ubuntu 24.04 + Unreal Engine 5.5.4, launching `apartment_0000` / `debug_0000` on an NVIDIA L4 GPU.
