### PR TITLE
Added guard to SpCore's callFunction against stale/dangling UObject handles

### DIFF
--- a/cpp/unreal_plugins/SpCore/Source/SpCore/UnrealUtils.cpp
+++ b/cpp/unreal_plugins/SpCore/Source/SpCore/UnrealUtils.cpp
@@ -166,6 +166,18 @@ std::map<std::string, SpPropertyValue> UnrealUtils::callFunction(const UWorld* w
     SP_ASSERT(world);
     SP_ASSERT(uobject);
     SP_ASSERT(ufunction);
+
+    // Ensure UFunction/UObject are not garbage-collected.
+    if (!ufunction->IsValidLowLevelFast()) {
+        SP_LOG("ERROR: callFunction: ufunction is a stale/invalid handle; refusing to call.");
+        SP_ASSERT(false);
+    }
+    if (!uobject->IsValidLowLevelFast()) {
+        SP_LOG("ERROR: callFunction: uobject is a stale/dangling handle (object was likely "
+               "garbage-collected or destroyed); function=", Unreal::toStdString(ufunction->GetName()));
+        SP_ASSERT(false);
+    }
+
     SP_ASSERT(!world->IsPreviewWorld());
     SP_ASSERT(GEngine->GetWorldContextFromWorld(world));
 


### PR DESCRIPTION
UnrealService::callFunction could SIGSEGV when a Python client called a reflected UFUNCTION on a UObject (or UFunction) that the engine had garbage-collected or destroyed since the handle was obtained. The raw pointer is non-null (so it passes the existing SP_ASSERT(uobject) / SP_ASSERT(ufunction)), but points at freed memory, and the crash lands deep in the reflected call with no indication of which function or object was at fault.

The PR adds an IsValidLowLevelFast() check on both ufunction and uobject immediately after the existing asserts to validate a possibly-garbage pointer (vtable + GUObjectArray index) without dereferencing user memory, so a stale handle now fails with a clear, catchable error that logs the offending function name instead of a segfault.