### PR TITLE
Log output with colors

### DIFF
--- a/python/spear/utils/log_utils.py
+++ b/python/spear/utils/log_utils.py
@@ -5,9 +5,23 @@
 
 import inspect
 import os
+import sys
+
+_RESET = "\033[0m"
+_COLORS = {
+    "black":   "30",
+    "red":     "31",
+    "green":   "32",
+    "yellow":  "33",
+    "blue":    "34",
+    "magenta": "35",
+    "cyan":    "36",
+    "white":   "37",
+}
 
 _default_log_enabled = True
 _log_funcs = []
+_supports_color_cached = None
 
 def get_default_log_enabled():
     return _default_log_enabled
@@ -24,11 +38,42 @@ def register_log_func(func):
 def unregister_log_func(func):
     _log_funcs.remove(func)
 
+# supports_color() follows the NO_COLOR/FORCE_COLOR conventions (https://no-color.org/) on top of the standard
+# library's own notion of whether stdout is a terminal (to avoid dumping escape codes to files for example)
+def supports_color():
+    global _supports_color_cached
+    if _supports_color_cached is not None:
+        return _supports_color_cached
+    _supports_color_cached = _supports_color()
+    return _supports_color_cached
+
+def _supports_color():
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("FORCE_COLOR") is not None:
+        return True
+    return sys.stdout.isatty()
+
+def colorize(text, color, bold=False):
+    if not supports_color():
+        return text
+    prefix = "1;" if bold else ""
+    return f"\033[{prefix}{_COLORS[color]}m{text}{_RESET}"
+
+def colorize_message_category(message):
+    message_lower = message.lower()
+    if "error" in message_lower or "exception" in message_lower:
+        print(colorize(text=message, color="red", bold=True))
+    elif "warning" in message_lower:
+        print(colorize(text=message, color="yellow"))
+    else:
+        print(message)
+
 def log(*args):
     current_frame = inspect.currentframe()
     message = _log_get_prefix(current_frame) + "".join([str(arg) for arg in args])
     if _default_log_enabled:
-        print(message)
+        print(colorize_message_category(message))
     for func in _log_funcs:
         func(message)
 

--- a/python/spear/utils/log_utils.py
+++ b/python/spear/utils/log_utils.py
@@ -62,11 +62,11 @@ def colorize(text, color, bold=False):
 def colorize_message_category(message):
     message_lower = message.lower()
     if "error" in message_lower or "exception" in message_lower:
-        print(colorize(text=message, color="red", bold=True))
+        return colorize(text=message, color="red", bold=True)
     elif "warning" in message_lower:
-        print(colorize(text=message, color="yellow"))
+        return colorize(text=message, color="yellow")
     else:
-        print(message)
+        return message
 
 def log(*args):
     current_frame = inspect.currentframe()

--- a/python/spear/utils/log_utils.py
+++ b/python/spear/utils/log_utils.py
@@ -42,9 +42,8 @@ def unregister_log_func(func):
 # library's own notion of whether stdout is a terminal (to avoid dumping escape codes to files for example)
 def supports_color():
     global _supports_color_cached
-    if _supports_color_cached is not None:
-        return _supports_color_cached
-    _supports_color_cached = _supports_color()
+    if _supports_color_cached is None:
+        _supports_color_cached = _supports_color()
     return _supports_color_cached
 
 def _supports_color():


### PR DESCRIPTION
This is a minor quality of life improvement to the python spear logging, I had this lying around for a while, so I thought why not submit it:)

The reason why I even initially added this was because in some cases, the logs are gigantic and I had trouble visually scanning the terminal output for issues. IMO this makes quite a difference:

<img width="300" height="183" alt="image" src="https://github.com/user-attachments/assets/12a80378-cf4a-42a4-917e-c33a8f247b76" />

<img width="300" height="183" alt="image" src="https://github.com/user-attachments/assets/74348323-5942-460a-b217-716cae05173d" />