### PR TITLE
Path tracer offline mode override

### DIFF
--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.cpp
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.cpp
@@ -381,6 +381,8 @@ void USpSceneCaptureComponent2D::Initialize()
     });
 
     request_path_tracer_reset_ = false;
+    request_override_is_offline_render_ = false;
+    request_is_offline_render_ = false;
     is_initialized_ = true;
     bIsInitialized = true;
 
@@ -489,6 +491,13 @@ void USpSceneCaptureComponent2D::RequestPathTracerReset()
     request_path_tracer_reset_ = true;
 }
 
+void USpSceneCaptureComponent2D::RequestSetOfflineRender(bool bOverrideIsOfflineRender, bool bIsOfflineRender)
+{
+    SP_ASSERT(IsInitialized());
+    request_override_is_offline_render_ = bOverrideIsOfflineRender;
+    request_is_offline_render_ = bIsOfflineRender;
+}
+
 void USpSceneCaptureComponent2D::setupView(FSceneViewFamily& view_family, FSceneView& view)
 {
     const TArray<FEngineShowFlagsSetting>& engine_show_flag_settings = GetShowFlagSettings();
@@ -504,13 +513,13 @@ void USpSceneCaptureComponent2D::setupView(FSceneViewFamily& view_family, FScene
         }
     }
 
-    if (bOverridePathTracerOfflineMode) {
-        view.bIsOfflineRender = bPathTracerOfflineMode;
-    }
-
     if (request_path_tracer_reset_) {
         view.bForcePathTracerReset = true;
         request_path_tracer_reset_ = false;
+    }
+
+    if (request_override_is_offline_render_) {
+        view.bIsOfflineRender = request_is_offline_render_;
     }
 }
 

--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.cpp
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.cpp
@@ -504,6 +504,10 @@ void USpSceneCaptureComponent2D::setupView(FSceneViewFamily& view_family, FScene
         }
     }
 
+    if (bOverridePathTracerOfflineMode) {
+        view.bIsOfflineRender = bPathTracerOfflineMode;
+    }
+
     if (request_path_tracer_reset_) {
         view.bForcePathTracerReset = true;
         request_path_tracer_reset_ = false;

--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.cpp
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.cpp
@@ -383,6 +383,7 @@ void USpSceneCaptureComponent2D::Initialize()
     request_path_tracer_reset_ = false;
     request_override_is_offline_render_ = false;
     request_is_offline_render_ = false;
+
     is_initialized_ = true;
     bIsInitialized = true;
 
@@ -398,6 +399,9 @@ void USpSceneCaptureComponent2D::Terminate()
     SetVisibility(false); // disable rendering to texture
 
     request_path_tracer_reset_ = false;
+    request_override_is_offline_render_ = false;
+    request_is_offline_render_ = false;
+
     is_initialized_ = false;
     bIsInitialized = false;
 

--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.h
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.h
@@ -150,6 +150,9 @@ public:
     UFUNCTION(BlueprintCallable, CallInEditor, Category="SPEAR")
     void RequestPathTracerReset();
 
+    UFUNCTION(BlueprintCallable, Category="SPEAR")
+    void RequestSetOfflineRender(bool bOverrideIsOfflineRender, bool bIsOfflineRender);
+
     // called from FSpSceneViewExtensionBase::shouldHandleView(...) when deciding whether or not this component matches the current view
     const TIndirectArray<FSceneViewStateReference>& getViewStates() const { return ViewStates; }
 
@@ -201,12 +204,6 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
     float TextureRenderTargetGamma = 0.0;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
-    bool bOverridePathTracerOfflineMode = false;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
-    bool bPathTracerOfflineMode = false;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
     UMaterial* Material = nullptr;
@@ -377,8 +374,10 @@ private:
     TextureReadbackDesc texture_readback_desc_;
     std::map<std::string, TextureReadbackDesc> user_scene_texture_readback_descs_;
 
-    // Path tracer state
-    std::atomic<bool> request_path_tracer_reset_ = false;
+    // Deferred state to be consumed in an FSceneViewExtension callback
+    bool request_path_tracer_reset_ = false;
+    bool request_override_is_offline_render_ = false;
+    bool request_is_offline_render_ = false;
 
     // Additional state for measuring "standalone" and "standalone + extra work" frame rates.
     FDelegateHandle begin_frame_handle_;

--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.h
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.h
@@ -147,9 +147,9 @@ public:
     UFUNCTION(Category="SPEAR") // uint64 not supported for BlueprintCallable, can't be const
     TArray<uint64> GetViewStates(); // FSceneViewStateInterface is not a UCLASS so we can't return FSceneViewStateInterface*, so we return uint64 instead
 
+    // Functions for setting deferred state that gets consumed in an FSceneViewExtension callback
     UFUNCTION(BlueprintCallable, CallInEditor, Category="SPEAR")
     void RequestPathTracerReset();
-
     UFUNCTION(BlueprintCallable, Category="SPEAR")
     void RequestSetOfflineRender(bool bOverrideIsOfflineRender, bool bIsOfflineRender);
 

--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.h
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpSceneCaptureComponent2D.h
@@ -203,6 +203,12 @@ public:
     float TextureRenderTargetGamma = 0.0;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
+    bool bOverridePathTracerOfflineMode = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
+    bool bPathTracerOfflineMode = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")
     UMaterial* Material = nullptr;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="SPEAR")


### PR DESCRIPTION
This overrides the scene view's offline mode, which changes how path tracer is invalidated. It's not needed for the simple path tracer example but can be useful for some experimental features. For example, you can use this to do manual motion blur, because in this mode the path tracer samples don't get invalidated on camera or object mvement.