### PR TITLE
Add Groom derived-data binding and enable HairStrands/AlembicHairImpo…

### DIFF
--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpGroomLibrary.h
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpGroomLibrary.h
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2025 The SPEAR Development Team. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+
+#pragma once
+
+#include <GroomAsset.h>
+#include <Kismet/BlueprintFunctionLibrary.h>
+#include <UObject/ObjectMacros.h> // GENERATED_BODY, UCLASS, UFUNCTION
+
+#include "SpGroomLibrary.generated.h"
+
+UCLASS()
+class USpGroomLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+    //
+    // UGroomAsset::CacheDerivedDatas() synchronously builds a Groom's derived
+    // "interpolation" render/simulation data. It is C++-only (not a UFUNCTION), so
+    // it isn't reachable through SPEAR's generic UFUNCTION-call reflection path
+    // without this wrapper -- and it matters that it IS reachable: using a
+    // freshly-imported/reconfigured GroomAsset before this has run (attaching it to
+    // a live GroomComponent, or even just letting the Editor's own deferred Content
+    // Browser thumbnail generation glance at it) crashes with "Assertion failed:
+    // !!(BulkData.Header.Flags & FHairStrandsInterpolationBulkData::DataFlags_HasData)".
+    // Calling this directly and synchronously avoids that failure mode entirely,
+    // instead of working around it with paced real-time ticks and Asset Editor
+    // open/close tricks from Python.
+    //
+    // Editor-only (WITH_EDITORONLY_DATA), like the underlying engine function --
+    // returns false in non-editor builds instead of failing to compile.
+    //
+    UFUNCTION(BlueprintCallable, Category="SPEAR")
+    static bool CacheGroomDerivedDatas(UGroomAsset* Groom)
+    {
+#if WITH_EDITORONLY_DATA
+        return Groom ? Groom->CacheDerivedDatas() : false;
+#else
+        return false;
+#endif
+    }
+};

--- a/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpUnrealTypes.Build.cs
+++ b/cpp/unreal_plugins/SpUnrealTypes/Source/SpUnrealTypes/SpUnrealTypes.Build.cs
@@ -19,7 +19,7 @@ public class SpUnrealTypes : SpModuleRules
         // files belonging to modules where the plugins are actually used.
         //
 
-        PublicDependencyModuleNames.AddRange(new string[] {"MovieRenderPipelineCore", "MovieRenderPipelineRenderPasses", "PCG", "SpCore"});
+        PublicDependencyModuleNames.AddRange(new string[] {"HairStrandsCore", "MovieRenderPipelineCore", "MovieRenderPipelineRenderPasses", "PCG", "SpCore"});
         PrivateDependencyModuleNames.AddRange(new string[] {});
     }
 }

--- a/cpp/unreal_plugins/SpUnrealTypes/SpUnrealTypes.uplugin
+++ b/cpp/unreal_plugins/SpUnrealTypes/SpUnrealTypes.uplugin
@@ -39,6 +39,10 @@
     "Plugins":
     [
         {
+            "Name": "HairStrands",
+            "Enabled": true
+        },
+        {
             "Name": "MovieRenderPipeline",
             "Enabled": true
         },

--- a/cpp/unreal_projects/SpearSim/SpearSim.uproject
+++ b/cpp/unreal_projects/SpearSim/SpearSim.uproject
@@ -26,6 +26,14 @@
             "Enabled": true
         },
         {
+            "Name": "AlembicHairImporter",
+            "Enabled": true
+        },
+        {
+            "Name": "HairStrands",
+            "Enabled": true
+        },
+        {
             "Name": "HDRIBackdrop",
             "Enabled": true
         },


### PR DESCRIPTION
…rter plugins

CacheDerivedDatas() on UGroomAsset is C++-only (not a UFUNCTION), so it's unreachable from Python through SPEAR's UFUNCTION-call reflection path. Without it, a freshly-imported GroomAsset's derived interpolation data is never built, and using it (attaching to a component, saving, even just Content Browser thumbnailing) crashes with a DataFlags_HasData assertion.

Adds a thin SpGroomLibrary.CacheGroomDerivedDatas() wrapper for this, and enables the HairStrands plugin (module dependency + project plugin) and AlembicHairImporter (project plugin, needed for .abc files to import as GroomAssets instead of silently falling back to StaticMesh).